### PR TITLE
fix. 주문 관련 로직 수정했습니다.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,5 +10,8 @@
         <module name="demo.main" />
       </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="demo.test" target="17" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/NBE2-3-1-Team1.iml" filepath="$PROJECT_DIR$/.idea/NBE2-3-1-Team1.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/demo.main.iml" filepath="$PROJECT_DIR$/.idea/modules/demo.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/demo.test.iml" filepath="$PROJECT_DIR$/.idea/modules/demo.test.iml" />
     </modules>
   </component>
 </project>

--- a/demo/src/main/java/com/example/demo/controller/CategoryController.java
+++ b/demo/src/main/java/com/example/demo/controller/CategoryController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,7 +23,7 @@ public class CategoryController {
 
     @Operation(summary = "카테고리 추가 API")
     @PostMapping()
-    public ResponseEntity<CategoryResponse.Create> createCategory(CategoryRequest.Create dto) {
+    public ResponseEntity<CategoryResponse.Create> createCategory(@RequestBody CategoryRequest.Create dto) {
         return ResponseEntity.ok().body(
                 CategoryResponse.Create.from(categoryService.createCategory(dto)));
     }

--- a/demo/src/main/java/com/example/demo/controller/OrderController.java
+++ b/demo/src/main/java/com/example/demo/controller/OrderController.java
@@ -4,7 +4,6 @@ import com.example.demo.dto.request.OrderRequest;
 import com.example.demo.dto.response.OrderResponse;
 import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderItem;
-import com.example.demo.repository.OrderRepository;
 import com.example.demo.service.OrderItemService;
 import com.example.demo.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,11 +28,13 @@ public class OrderController {
 
     @Operation(summary = "주문 생성 API")
     @PostMapping
-    public ResponseEntity<OrderResponse.Create> createOrder(OrderRequest.Create dto) {
-        Order order = orderService.createOrder(dto, orderItemService.getOrderItemsWithoutOrder());
+    public ResponseEntity<OrderResponse.Create> createOrder(@RequestBody OrderRequest.Create dto) {
+        Order order = orderService.createOrder(dto);
+        List<OrderItem> resultOrderItems =
+                orderItemService.updateOrderItemsByOrder(orderItemService.getAllByOrder(order), orderItemService.getAllByOrderIsNull(), order);
 
         return ResponseEntity.ok().body(
-                OrderResponse.Create.from(order, orderItemService.getOrderItemsByOrderId(order.getId()))
+                OrderResponse.Create.from(order, resultOrderItems)
         );
     }
 

--- a/demo/src/main/java/com/example/demo/controller/OrderItemController.java
+++ b/demo/src/main/java/com/example/demo/controller/OrderItemController.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,8 +24,16 @@ public class OrderItemController {
 
     @PostMapping
     @Operation(summary = "장바구니 추가 API")
-    public ResponseEntity<OrderItemResponse.Create> createOrderItem(OrderItemRequest.Create dto) {
+    public ResponseEntity<OrderItemResponse.Create> createOrderItem(@RequestBody OrderItemRequest.Create dto) {
         return ResponseEntity.ok().body(
                 OrderItemResponse.Create.from(orderItemService.createOrderItem(dto, itemService.getItemById(dto.itemId()))));
+    }
+
+    @GetMapping
+    @Operation(summary = "장바구니 전체 조회 API")
+    public ResponseEntity<OrderItemResponse.ReadAll> getAllOrderItems() {
+        return ResponseEntity.ok().body(
+                OrderItemResponse.ReadAll.from(orderItemService.getAllByOrderIsNull())
+        );
     }
 }

--- a/demo/src/main/java/com/example/demo/dto/response/OrderItemResponse.java
+++ b/demo/src/main/java/com/example/demo/dto/response/OrderItemResponse.java
@@ -1,7 +1,10 @@
 package com.example.demo.dto.response;
 
 import com.example.demo.entity.Item;
+import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderItem;
+
+import java.util.List;
 
 public record OrderItemResponse() {
 
@@ -12,6 +15,25 @@ public record OrderItemResponse() {
     ) {
         public static OrderItemResponse.Create from(OrderItem orderItem) {
             return new OrderItemResponse.Create(orderItem.getItem().getId(), orderItem.getItem().getName(), orderItem.getQuantity());
+        }
+    }
+
+    public record Read(
+            Long itemId,
+            int quantity
+    ) {
+        public static OrderItemResponse.Read from(OrderItem orderItem) {
+            return new OrderItemResponse.Read(orderItem.getItem().getId(), orderItem.getQuantity());
+        }
+    }
+
+    public record ReadAll(
+            List<Read> orderItems
+    ) {
+        public static OrderItemResponse.ReadAll from(List<OrderItem> orderItems) {
+            return new OrderItemResponse.ReadAll(
+                    orderItems.stream().map(Read::from).toList()
+            );
         }
     }
 }

--- a/demo/src/main/java/com/example/demo/entity/OrderItem.java
+++ b/demo/src/main/java/com/example/demo/entity/OrderItem.java
@@ -1,7 +1,6 @@
 package com.example.demo.entity;
 
 
-import com.example.demo.dto.request.OrderItemRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,8 +44,12 @@ public class OrderItem {
                 .build();
     }
 
-    public void createOrder(Order order) {
+    public void updateOrder(Order order) {
         this.order = order;
+    }
+
+    public void addQuantity(int quantity) {
+        this.quantity += quantity;
     }
 
     public void addQuantity() {

--- a/demo/src/main/java/com/example/demo/repository/OrderItemRepository.java
+++ b/demo/src/main/java/com/example/demo/repository/OrderItemRepository.java
@@ -10,10 +10,10 @@ import java.util.Optional;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
-    Optional<List<OrderItem>> findByOrderIsNull();
+    Optional<List<OrderItem>> findAllByOrderIsNull();
 
-    List<OrderItem> findByOrderId(Long orderId);
+    List<OrderItem> findByOrder(Order order);
 
-    OrderItem findByItem(Item item);
+    OrderItem findByItemAndOrderIsNull(Item item);
 
 }

--- a/demo/src/main/java/com/example/demo/repository/OrderRepository.java
+++ b/demo/src/main/java/com/example/demo/repository/OrderRepository.java
@@ -4,8 +4,11 @@ import com.example.demo.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    Order findByDeliveryDate(LocalDateTime deliveryDate);
+    Order findByDeliveryDateAndEmail(LocalDateTime deliveryDate, String email);
+
+    List<Order> email(String email);
 }

--- a/demo/src/main/java/com/example/demo/service/OrderItemService.java
+++ b/demo/src/main/java/com/example/demo/service/OrderItemService.java
@@ -2,6 +2,7 @@ package com.example.demo.service;
 
 import com.example.demo.dto.request.OrderItemRequest;
 import com.example.demo.entity.Item;
+import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderItem;
 import com.example.demo.repository.OrderItemRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -9,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +22,7 @@ public class OrderItemService {
 
     @Transactional
     public OrderItem createOrderItem(OrderItemRequest.Create dto, Item item) {
-        OrderItem orderItem = orderItemRepository.findByItem(item);
+        OrderItem orderItem = orderItemRepository.findByItemAndOrderIsNull(item);
 
         if (orderItem == null) {
             return orderItemRepository.save(OrderItem.toOrderItem(item));
@@ -30,14 +33,47 @@ public class OrderItemService {
         return orderItem;
     }
 
+    @Transactional
+    public List<OrderItem> updateOrderItemsByOrder(List<OrderItem> orderItemsByOrder, List<OrderItem> orderItemsByOrderIsNull, Order order) {
+        Map<Long, OrderItem> mergedOrderItems = new HashMap<>();
+
+        for (OrderItem orderItem : orderItemsByOrder) {
+            Long key = orderItem.getItem().getId();
+            mergedOrderItems.put(key, orderItem);
+        }
+
+        for (OrderItem orderItem : orderItemsByOrderIsNull) {
+            Long key = orderItem.getItem().getId();
+            if (mergedOrderItems.containsKey(key)) {
+                mergedOrderItems.get(key).addQuantity(orderItem.getQuantity());
+            } else {
+                orderItem.updateOrder(order);
+                mergedOrderItems.put(key, orderItem);
+            }
+        }
+
+        orderItemsByOrder.clear();
+        orderItemsByOrder.addAll(mergedOrderItems.values());
+
+        clearOrderItemsAfterOrder();
+
+        return orderItemsByOrder;
+    }
+
     @Transactional(readOnly = true)
-    public List<OrderItem> getOrderItemsWithoutOrder() {
-        return orderItemRepository.findByOrderIsNull()
+    public List<OrderItem> getAllByOrderIsNull() {
+        return orderItemRepository.findAllByOrderIsNull()
                 .orElseThrow(() -> new EntityNotFoundException("장바구니가 존재하지 않습니다."));
     }
 
     @Transactional(readOnly = true)
-    public List<OrderItem> getOrderItemsByOrderId(Long orderId) {
-        return orderItemRepository.findByOrderId(orderId);
+    public List<OrderItem> getAllByOrder(Order order) {
+        return orderItemRepository.findByOrder(order);
+    }
+
+    @Transactional
+    public void clearOrderItemsAfterOrder() {
+        List<OrderItem> orderItems = getAllByOrderIsNull();
+        orderItemRepository.deleteAll(orderItems);
     }
 }

--- a/demo/src/main/java/com/example/demo/service/OrderService.java
+++ b/demo/src/main/java/com/example/demo/service/OrderService.java
@@ -2,17 +2,14 @@ package com.example.demo.service;
 
 import com.example.demo.dto.request.OrderRequest;
 import com.example.demo.entity.Order;
-import com.example.demo.entity.OrderItem;
 import com.example.demo.entity.OrderStatus;
 import com.example.demo.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -21,7 +18,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public Order createOrder(OrderRequest.Create dto, List<OrderItem> orderItems) {
+    public Order createOrder(OrderRequest.Create dto) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime deliveryDate;
 
@@ -31,29 +28,20 @@ public class OrderService {
             deliveryDate = LocalDate.now().plusDays(1).atTime(14, 0);
         }
 
-        Order order = orderRepository.findByDeliveryDate(deliveryDate);
+        Order order = getOrderByDeliveryDateAndEmail(deliveryDate, dto.email());
 
         if (order == null) {
-            order = createNewOrder(dto, orderItems, now.getHour() < 14 ? OrderStatus.DELIVERING : OrderStatus.PREPARING, deliveryDate);
-        } else {
-            addOrderItemsToOrder(order, orderItems);
+            return orderRepository.save(Order.toOrder(dto, now.getHour() > 14 ? OrderStatus.PREPARING : OrderStatus.DELIVERING, deliveryDate));
         }
 
         return order;
     }
 
-    private Order createNewOrder(OrderRequest.Create dto, List<OrderItem> orderItems, OrderStatus status, LocalDateTime deliveryDate) {
-        Order order = Order.toOrder(dto, status, deliveryDate);
-        for (OrderItem orderItem : orderItems) {
-            orderItem.createOrder(order);
-        }
-        return orderRepository.save(order);
-    }
 
-    private void addOrderItemsToOrder(Order order, List<OrderItem> orderItems) {
-        for (OrderItem orderItem : orderItems) {
-            orderItem.createOrder(order);
-        }
-    }
 
+    @Transactional(readOnly = true)
+    public Order getOrderByDeliveryDateAndEmail(LocalDateTime deliveryDate, String email) {
+        return orderRepository.findByDeliveryDateAndEmail(deliveryDate, email);
+    }
 }
+


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 로직 수정
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. Map의 key를 활용해서 기존 주문이 존재한다면 수량을 업데이트 하도록 수정
2. 수량을 수정 후 주문 전에 넣어둔 장바구니 데이터가 그대로 살아있는 문제가 있어 order가 null인 장바구니를 삭제
3. Order와 OrderItem 에 @RequestBody를 사용하지 않은 컨트롤러가 있어 수정

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
주문 - 장바구니 - 주문 상세 이렇게 테이블을 나누지 않아
최초 장바구니 생성 시 장바구니 테이블 속 Order을 null로 선언 후 주문 시 업데이트 해줬습니다.